### PR TITLE
Dialog title fix

### DIFF
--- a/advanced_search.js
+++ b/advanced_search.js
@@ -76,13 +76,14 @@
             height: 300,
             resizable: true,
             draggable: true,
-            title: title,
             dialogClass: "advanced_search_dialog",
             close: function() {
                 $('body').css('overflow', 'auto');
             },
             create: function() {
                 $('body').css('overflow', 'hidden');
+                $(this).siblings().find(".ui-dialog-title").html(title);
+                
             }
         });
 


### PR DESCRIPTION
The newer jquery plugin shipped starting from RC 1.1 supports only plain text in the title property.
This fix appends the search object to the title during the dialog creation.
